### PR TITLE
add chairs for SIG device-iot

### DIFF
--- a/sig-device-iot/README.md
+++ b/sig-device-iot/README.md
@@ -6,10 +6,37 @@ The [charter](./charter.md) defines the scope and governance of the Device IoT S
 
 ## Meetings
 
-* Regular SIG Meeting: [Friday at 10:00 UTC+8](https://zoom.us/j/4167237304) (biweekly, starts on Sep. 25th 2020). [Convert to your timezone](https://www.thetimezoneconverter.com/?t=10%3A00%20am&tz=GMT%2B8&).
- * [Meeting notes and Agenda](https://docs.google.com/document/d/1PeuZzfLjU8oIduKI2nFeckKAhhckME4tqCZ33WmORBI/edit#heading=h.252sw1n3b1vb).
- * [Meeting Calendar](https://calendar.google.com/calendar/embed?src=8rjk8o516vfte21qibvlae3lj4%40group.calendar.google.com) | [Subscribe](https://calendar.google.com/calendar?cid=OHJqazhvNTE2dmZ0ZTIxcWlidmxhZTNsajRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
+* Regular SIG Meeting: [Friday at 15:30-16:30 UTC+8](https://zoom.us/j/4167237304) (biweekly, starts on Sep. 25th 2020). [Convert to your timezone](https://www.thetimezoneconverter.com/?t=10%3A00%20am&tz=GMT%2B8&).
+* [Meeting notes and Agenda (en)](https://docs.google.com/document/d/1PeuZzfLjU8oIduKI2nFeckKAhhckME4tqCZ33WmORBI/edit#heading=h.252sw1n3b1vb).
+* [Meeting notes and Agenda (zh)](https://shimo.im/docs/RKAWVexBG6cKZlk8).
+* [Meeting Calendar](https://calendar.google.com/calendar/embed?src=8rjk8o516vfte21qibvlae3lj4%40group.calendar.google.com) | [Subscribe](https://calendar.google.com/calendar?cid=OHJqazhvNTE2dmZ0ZTIxcWlidmxhZTNsajRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
  
 ## Contact
+
 - Slack: [#sig-device-iot](https://kubeedge.slack.com/archives/C01239D6PM4)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubeedge)
+
+## Leadership
+
+### Chairs
+
+The Chairs of the SIG run operations and processes governing the SIG.
+
+- Fei Xu (@fisherxu), Huawei
+- Chenlin Liu (@cl2017), DaoCloud
+
+
+### Technical Leads
+
+The Technical Leads of the SIG establish new subprojects, decommission existing subprojects, and resolve cross-subproject technical issues and decisions.
+
+- Fei Xu (@fisherxu), Huawei
+- Chenlin Liu (@cl2017), DaoCloud
+
+## Subprojects
+
+The following subprojects are owned by sig-device-iot:
+
+### mappers-go
+- **Owners:**
+  - [kubeedge/mappers-go](https://github.com/kubeedge/mappers-go/blob/main/OWNERS)


### PR DESCRIPTION
@fisherxu and @cl2017 have been contributed in SIG-Device-iot development for a long time, have also organized community SIG meetings, and will continue to work on the development of the SIG, so this PR will added them to SIG Chairs and Technical Leads

update-device-iot README.md

Signed-off-by: cl2017 <chenlin.liu@daocloud.io>