### PR TITLE
add SIG Networking chairs

### DIFF
--- a/sig-networking/README.md
+++ b/sig-networking/README.md
@@ -21,7 +21,8 @@ The [charter](charter.md) defines the scope and governance of the Networking Spe
 
 The Chairs of the SIG run operations and processes governing the SIG.
 
-*TODO*
+- Jiawei Liu (@JiaweiGithub), DaoCloud
+- Jiezhang Wang (@Poorunga), Huawei
 
 ### Technical Leads
 


### PR DESCRIPTION
@Poorunga is also one of the founders of SIG Networking and participated in and initiated the establishment of SIG Networking. In addition, edgemesh is the first project of SIG Networking. @Poorunga, as one of the maintainers of the edgemesh repo, has participated in the development of the edgemesh project for a long time.

@JiaweiGithub loves cloud native technology and edge computing technology, and is also a contributor to the kubeedge and edgemesh projects. He contributed a lot of code and ideas to the kubeedge community, and also participated in community activities.