### PR TITLE
Add DaoCloud to Private Distributors List

### DIFF
--- a/team-security/security-groups.md
+++ b/team-security/security-groups.md
@@ -10,6 +10,11 @@ cncf-kubeedge-distrib-announce@lists.cncf.io
 
 Maintained by [Security Team](#the-security-team).
 
+Members:
+
+- kubeedge-security@daocloud.io
+
+
 ### The Security Team
 
 Email:


### PR DESCRIPTION
Daocloud has applied for membership of private distributors list, add meets the criteria.

Fixes: https://github.com/kubeedge/community/issues/154
