### PR TITLE
Fix slack url

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership-request.md
+++ b/.github/ISSUE_TEMPLATE/membership-request.md
@@ -40,7 +40,7 @@ assignees: ''
 <!-- Please don't edit the following lines -->
 [community membership guidelines]: https://github.com/kubeedge/community/blob/master/community-membership.md
 [mailing list]: https://groups.google.com/forum/#!forum/kubeedge
-[slack]: https://kubeedge.slack.com/
+[slack]: https://kubeedge.io/docs/community/slack/
 [watchers list]: https://github.com/kubeedge/kubeedge/watchers
 [two-factor authentication]: https://help.github.com/en/github/authenticating-to-github/about-two-factor-authentication
 [devstats]: https://kubeedge.devstats.cncf.io/d/56/company-commits-table?orgId=1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you need support, start with the [troubleshooting guide], and work your way t
 If you have questions, feel free to reach out to us in the following ways:
 
 - [mailing list](https://groups.google.com/forum/#!forum/kubeedge)
-- [slack](https://join.slack.com/t/kubeedge/shared_invite/enQtNjc0MTg2NTg2MTk0LWJmOTBmOGRkZWNhMTVkNGU1ZjkwNDY4MTY4YTAwNDAyMjRkMjdlMjIzYmMxODY1NGZjYzc4MWM5YmIxZjU1ZDI)
+- [slack](https://kubeedge.io/docs/community/slack/)
 - [twitter](https://twitter.com/kubeedge)
 
 

--- a/contribute.md
+++ b/contribute.md
@@ -40,7 +40,7 @@ The goal of the community is to develop a cloud native edge computing platform b
 
 We will help you to contribute in different areas like filing issues, developing features, fixing critical bugs and getting your work reviewed and merged.
 
-If you have questions about the development process, feel free to jump into our [Slack Channel](https://join.slack.com/t/kubeedge/shared_invite/enQtNjc0MTg2NTg2MTk0LWJmOTBmOGRkZWNhMTVkNGU1ZjkwNDY4MTY4YTAwNDAyMjRkMjdlMjIzYmMxODY1NGZjYzc4MWM5YmIxZjU1ZDI) or join our [mailing list](https://groups.google.com/forum/#!forum/kubeedge).
+If you have questions about the development process, feel free to jump into our [Slack Channel](https://kubeedge.io/docs/community/slack/) or join our [mailing list](https://groups.google.com/forum/#!forum/kubeedge).
 
 ## Find something to work on
 

--- a/sig-ai/README.md
+++ b/sig-ai/README.md
@@ -13,5 +13,5 @@ The [charter](charter.md) defines the scope and governance of the AI Special Int
  * [Meeting Calendar](https://calendar.google.com/calendar/u/0?cid=Y19nODluOXAwOG05MzFiYWM3NmZsajgwZzEwOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) | [Subscribe](https://calendar.google.com/calendar?cid=OHJqazhvNTE2dmZ0ZTIxcWlidmxhZTNsajRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
  
 ## Contact
-- Slack: [#sig-ai](https://app.slack.com/client/TDZ5TGXQW/C01EG84REVB)
+- Slack: [#sig-ai](https://kubeedge.io/docs/community/slack/)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubeedge)

--- a/sig-device-iot/README.md
+++ b/sig-device-iot/README.md
@@ -13,7 +13,7 @@ The [charter](./charter.md) defines the scope and governance of the Device IoT S
  
 ## Contact
 
-- Slack: [#sig-device-iot](https://kubeedge.slack.com/archives/C01239D6PM4)
+- Slack: [#sig-device-iot](https://kubeedge.io/docs/community/slack/)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubeedge)
 
 ## Leadership

--- a/sig-mec/README.md
+++ b/sig-mec/README.md
@@ -9,6 +9,6 @@ to build end to end platforms, and provides necessary use cases to demonstrate t
   -  [Meeting Calendar](https://calendar.google.com/calendar/u/0?cid=Y19nODluOXAwOG05MzFiYWM3NmZsajgwZzEwOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) | [Subscribe](https://calendar.google.com/calendar?cid=OHJqazhvNTE2dmZ0ZTIxcWlidmxhZTNsajRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
  
 ## Contact
-- Slack: [#sig-mec](https://kubeedge.slack.com/archives/C0120QT37PD)
+- Slack: [#sig-mec](https://kubeedge.io/docs/community/slack/)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubeedge)
     

--- a/sig-networking/README.md
+++ b/sig-networking/README.md
@@ -11,7 +11,7 @@ The [charter](charter.md) defines the scope and governance of the Networking Spe
 
 ## Contact
 
-- [#sig-networking slack channel](https://kubeedge.slack.com)
+- [#sig-networking slack channel](https://kubeedge.io/docs/community/slack/)
 - [Open Community Issues](https://github.com/kubeedge/community/issues)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubeedge)
 

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -10,7 +10,7 @@ The [charter](https://github.com/kubeedge/community/blob/master/sig-node/charter
 
 ## Contact
 
-- Slack: [#sig-node slack channel](https://kubeedge.slack.com)
+- Slack: [#sig-node slack channel](https://kubeedge.io/docs/community/slack/)
 
 - [Open Community Issues](https://github.com/kubeedge/kubeedge/issues)
 

--- a/sig-robotics/README.md
+++ b/sig-robotics/README.md
@@ -13,7 +13,7 @@ The [charter](charter.md) defines the scope and governance of the Robotics Speci
 
 ## Contact
 
-- [#sig-Robotics slack channel](https://kubeedge.slack.com/archives/C05H44JKB0Q)
+- [#sig-Robotics slack channel](https://kubeedge.io/docs/community/slack/)
 - [Open Community Issues](https://github.com/kubeedge/community/issues)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubeedge)
 

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -12,7 +12,7 @@ The [charter](https://github.com/kubeedge/community/blob/master/sig-scalability/
 
 ## Contact
 
-- [#sig-scalability slack channel](https://kubeedge.slack.com)
+- [#sig-scalability slack channel](https://kubeedge.io/docs/community/slack/)
 - [Open Community Issues](https://github.com/kubeedge/community/issues)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubeedge)
 

--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -11,7 +11,7 @@ The SIG SECURITY members will work with the security team for fixing and disclos
 
 ## Contact
 
-- [#sig-security slack channel](https://kubeedge.slack.com)
+- [#sig-security slack channel](https://kubeedge.io/docs/community/slack/)
 - [Open Community Issues](https://github.com/kubeedge/community/issues)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubeedge)
 

--- a/sig-security/joint-review.md
+++ b/sig-security/joint-review.md
@@ -276,12 +276,12 @@ All code is maintained in [GitHub](https://github.com/kubeedge/kubeedge) and cha
 - Internal. How do team members communicate with each other?
   
 
-Team members communicate with each other frequently through [Slack Channel](https://join.slack.com/t/kubeedge/shared_invite/enQtNjc0MTg2NTg2MTk0LWJmOTBmOGRkZWNhMTVkNGU1ZjkwNDY4MTY4YTAwNDAyMjRkMjdlMjIzYmMxODY1NGZjYzc4MWM5YmIxZjU1ZDI), [KubeEdge sync meeting](https://zoom.us/my/kubeedge), and team members will open a new [issue](https://github.com/kubeedge/kubeedge/issues) to further discuss if necessary.
+Team members communicate with each other frequently through [Slack Channel](https://kubeedge.io/docs/community/slack/), [KubeEdge sync meeting](https://zoom.us/my/kubeedge), and team members will open a new [issue](https://github.com/kubeedge/kubeedge/issues) to further discuss if necessary.
 
 - Inbound. How do users or prospective users communicate with the team?
   
 
-Users or prospective users usually communicate with the team through [Slack Channel](https://kubeedge.slack.com/archives/CDXVBS085), you can open a new [issue](https://github.com/kubeedge/kubeedge/issues) to get further help from the team, and [KubeEdge mailing list](https://groups.google.com/forum/#!forum/kubeedge) is also available. Besides, we have regular [community meeting](https://zoom.us/my/kubeedge) (includes SIG meetings) alternative between Europe friendly time and Pacific friendly time. All these meetings are publicly accessible and meeting records are uploaded to YouTube.
+Users or prospective users usually communicate with the team through [Slack Channel](https://kubeedge.io/docs/community/slack/), you can open a new [issue](https://github.com/kubeedge/kubeedge/issues) to get further help from the team, and [KubeEdge mailing list](https://groups.google.com/forum/#!forum/kubeedge) is also available. Besides, we have regular [community meeting](https://zoom.us/my/kubeedge) (includes SIG meetings) alternative between Europe friendly time and Pacific friendly time. All these meetings are publicly accessible and meeting records are uploaded to YouTube.
 
 Regular Community Meetings:
 
@@ -291,7 +291,7 @@ Regular Community Meetings:
 - Outbound. How do you communicate with your users? (e.g. flibble-announce@ mailing list)
   
 
-KubeEdge communicates with users through [Slack Channel](https://kubeedge.slack.com/archives/CUABZBD55), [issues](https://github.com/kubeedge/kubeedge/issues), [KubeEdge sync meetings](https://zoom.us/my/kubeedge), [KubeEdge mailing list](https://groups.google.com/forum/#!forum/kubeedge). As for security issues, we provide the following channel:
+KubeEdge communicates with users through [Slack Channel](https://kubeedge.io/docs/community/slack/), [issues](https://github.com/kubeedge/kubeedge/issues), [KubeEdge sync meetings](https://zoom.us/my/kubeedge), [KubeEdge mailing list](https://groups.google.com/forum/#!forum/kubeedge). As for security issues, we provide the following channel:
 
 - Security email group
 

--- a/sig-security/self-assessment.md
+++ b/sig-security/self-assessment.md
@@ -123,11 +123,11 @@ All code is maintained in [GitHub](https://github.com/kubeedge/kubeedge) and cha
 
 - Internal. How do team members communicate with each other?
 
-Team members communicate with each other frequently through [Slack Channel](https://join.slack.com/t/kubeedge/shared_invite/enQtNjc0MTg2NTg2MTk0LWJmOTBmOGRkZWNhMTVkNGU1ZjkwNDY4MTY4YTAwNDAyMjRkMjdlMjIzYmMxODY1NGZjYzc4MWM5YmIxZjU1ZDI), [KubeEdge sync meeting](https://zoom.us/my/kubeedge), and team members will open a new [issue](https://github.com/kubeedge/kubeedge/issues) to further discuss if necessary.
+Team members communicate with each other frequently through [Slack Channel](https://kubeedge.io/docs/community/slack/), [KubeEdge sync meeting](https://zoom.us/my/kubeedge), and team members will open a new [issue](https://github.com/kubeedge/kubeedge/issues) to further discuss if necessary.
 
 - Inbound. How do users or prospective users communicate with the team?
 
-Users or prospective users usually communicate with the team through [Slack Channel](https://kubeedge.slack.com/archives/CDXVBS085), you can open a new [issue](https://github.com/kubeedge/kubeedge/issues) to get further help from the team, and [KubeEdge mailing list](https://groups.google.com/forum/#!forum/kubeedge) is also available. Besides, we have regular [community meeting](https://zoom.us/my/kubeedge) (includes SIG meetings) alternative between Europe friendly time and Pacific friendly time. All these meetings are publicly accessible and meeting records are uploaded to YouTube.
+Users or prospective users usually communicate with the team through [Slack Channel](https://kubeedge.io/docs/community/slack/), you can open a new [issue](https://github.com/kubeedge/kubeedge/issues) to get further help from the team, and [KubeEdge mailing list](https://groups.google.com/forum/#!forum/kubeedge) is also available. Besides, we have regular [community meeting](https://zoom.us/my/kubeedge) (includes SIG meetings) alternative between Europe friendly time and Pacific friendly time. All these meetings are publicly accessible and meeting records are uploaded to YouTube.
 
 Regular Community Meetings:
 
@@ -136,7 +136,7 @@ Regular Community Meetings:
 
 - Outbound. How do you communicate with your users? (e.g. flibble-announce@ mailing list)
 
-KubeEdge communicates with users through [Slack Channel](https://kubeedge.slack.com/archives/CUABZBD55), [issues](https://github.com/kubeedge/kubeedge/issues), [KubeEdge sync meetings](https://zoom.us/my/kubeedge), [KubeEdge mailing list](https://groups.google.com/forum/#!forum/kubeedge). As for security issues, we provide the following channel:
+KubeEdge communicates with users through [Slack Channel](https://kubeedge.io/docs/community/slack/), [issues](https://github.com/kubeedge/kubeedge/issues), [KubeEdge sync meetings](https://zoom.us/my/kubeedge), [KubeEdge mailing list](https://groups.google.com/forum/#!forum/kubeedge). As for security issues, we provide the following channel:
 
 - Security email group
 

--- a/support.md
+++ b/support.md
@@ -7,7 +7,7 @@ If you need support, start with the [troubleshooting guide](https://github.com/k
 
 **Slack channel:**
 
-We use Slack for public discussions. To chat with us or the rest of the community, join us in the [KubeEdge Slack](https://kubeedge.slack.com) team channel #general. To sign up, use our Slack inviter link [here](https://join.slack.com/t/kubeedge/shared_invite/enQtNDg1MjAwMDI0MTgyLTQ1NzliNzYwNWU5MWYxOTdmNDZjZjI2YWE2NDRlYjdiZGYxZGUwYzkzZWI2NGZjZWRkZDVlZDQwZWI0MzM1Yzc).
+We use Slack for public discussions. To chat with us or the rest of the community, join us in the [KubeEdge Slack](https://kubeedge.slack.com) team channel #general. To sign up, use our Slack inviter link [here](https://kubeedge.io/docs/community/slack/).
 
 **Mailing List**  
 

--- a/team-security/comms-templates/non-vuln-response.md
+++ b/team-security/comms-templates/non-vuln-response.md
@@ -3,7 +3,7 @@ Thank you for your message.
 It appears this report is neither a vulnerability report nor a security incident. Consider one of these public options instead:
 
 - open an issue: https://github.com/kubeedge/kubeedge/issues/new/choose
-- #kubeedge-security slack channel: https://kubeedge.slack.com
+- #kubeedge-security slack channel: https://kubeedge.io/docs/community/slack/
 
 Thank you,
 

--- a/team-security/security-release-process.md
+++ b/team-security/security-release-process.md
@@ -120,7 +120,7 @@ Communications process:
   announcement should be actionable, and include any mitigating steps users can take prior to
   upgrading to a fixed version. The announcement will be sent via the following channels:
   - General announcement email ([template](comms-templates/distributors-announcement-email.md)) to multiple KubeEdge lists
-  - [#announcement slack channel](https://kubeedge.slack.com/archives/CUABZBD55) ([template](comms-templates/vulnerability-announcement-slack.md))
+  - [#announcement slack channel](https://kubeedge.io/docs/community/slack/) ([template](comms-templates/vulnerability-announcement-slack.md))
   - Tracking issue opened in https://github.com/kubeedge/kubeedge/issues ([template](comms-templates/vulnerability-announcement-issue.md)) and prefixed with the associated CVE ID (if applicable)
   - [GitHub Security Advisories](https://github.com/kubeedge/kubeedge/security/advisories) of KubeEdge
   - [Patch release](https://github.com/kubeedge/kubeedge/releases), will have the fix details included in the patch release notes. Any public announcement sent for these fixes will link to the release notes.

--- a/wg-wireless/README.md
+++ b/wg-wireless/README.md
@@ -14,7 +14,7 @@ KubeEdge Wireless Working group is responsible to simplify, develop, and optimiz
 
 ## Contact
 
-- Slack: [#sig-mec](https://kubeedge.slack.com/archives/C0120QT37PD)
+- Slack: [#sig-mec](https://kubeedge.io/docs/community/slack/)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubeedge)
 
 This working group currently sponsored by sig-mec with a focus on improving ability of management and developing of KubeEdge in wireless scenario.


### PR DESCRIPTION
Update slack invitation link to CNCF, ref: https://github.com/kubeedge/community/issues/185 