### PR TITLE
Nominate chair and tech lead for SIG testing

### DIFF
--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -20,11 +20,12 @@ The [charter](https://github.com/kubeedge/community/blob/master/sig-testing/char
 
 The Chairs of the SIG run operations and processes governing the SIG.
 
-*TODO*
+- Yue Li (@liyuerich), DaoCloud
+- Shelley Bao (@Shelley-BaoYue), Huawei
 
 ### Technical Leads
 
 The Technical Leads of the SIG establish new subprojects, decommission existing subprojects, and resolve cross-subproject technical issues and decisions.
 
 - Shelley Bao (@Shelley-BaoYue), Huawei
-
+- Yue Li (@liyuerich), DaoCloud


### PR DESCRIPTION
1. Nominate @liyuerich from DaoCloud as chair and tech leader for SIG testing, as liyue's team has made a lot of contributions for testing to the community, including:

- K8s multi-version compatible e2e test
- Keadm multi-version compatible e2e test
- KubeEdge conformance test
- ...
- Attending regular community meeting
https://github.com/kubeedge/kubeedge/pulls?q=is%3Apr+author%3Awlq1212+is%3Aclosed
https://github.com/kubeedge/kubeedge/pull/5663



2. Nominate @Shelley-BaoYue as SIG chair, who has served as tech leader for more than two years.


/cc @liyuerich @Shelley-BaoYue 
/assign @kubeedge/tsc 
/hold