### PR TITLE
CNCF Governance Review: Make security reporting information be more easily findable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ If you're interested in being a contributor and want to get involved in
 developing the KubeEdge code, please see [contribute](./contribute.md) for
 details on submitting patches and the contribution workflow.
 
+## Reporting security vulnerabilities
+
+We encourage security researchers, industry organizations and users to proactively report suspected vulnerabilities to our security team (`cncf-kubeedge-security@lists.cncf.io`), the team will help diagnose the severity of the issue and determine how to address the issue as soon as possible.
+
+For further details please see [Security Policy](https://github.com/kubeedge/community/blob/master/team-security/SECURITY.md) for our security process and how to report vulnerabilities.
+
+
 ## Membership
 We encourage all contributors to become members. Learn more about requirements and responsibilities of membership in our [Community Membership doc](./community-membership.md).
 

--- a/team-security/README.md
+++ b/team-security/README.md
@@ -10,3 +10,9 @@ The Security Team is responsible for receiving and responding to reports of secu
 ### Members
 
 Membership details are maintained [here](security-groups.md) under the section `The Security Team`.
+
+## Reporting security vulnerabilities
+
+We encourage security researchers, industry organizations and users to proactively report suspected vulnerabilities to our security team (`cncf-kubeedge-security@lists.cncf.io`), the team will help diagnose the severity of the issue and determine how to address the issue as soon as possible.
+
+For further details please see [Security Policy](https://github.com/kubeedge/community/blob/master/team-security/SECURITY.md) for our security process and how to report vulnerabilities.

--- a/team-security/SECURITY.md
+++ b/team-security/SECURITY.md
@@ -13,6 +13,7 @@ The information of the Security Team members is described as follows:
 | Kevin Wang ([@kevin-wangzefeng](https://github.com/kevin-wangzefeng)) | wangzefeng@huawei.com |
 | Fisher Xu ([@fisherxu](https://github.com/fisherxu))         | xufei40@huawei.com    |
 | Vincent Lin ([@vincentgoat](https://github.com/vincentgoat)) | linguohui1@huawei.com |
+| Wei Hu ([@WillardHu](https://github.com/WillardHu))          | wei.hu@daocloud.io |
 
 ### E-mail Response
 


### PR DESCRIPTION
Security reporting information should be more easily findable, so adding some entry points for reporting security vulnerabilities.

And we also have the link in main repo: https://github.com/kubeedge/kubeedge?tab=readme-ov-file#reporting-security-vulnerabilities