### PR TITLE
CNCF Governance Review: Updates for team security member

### DIFF
--- a/team-security/README.md
+++ b/team-security/README.md
@@ -1,6 +1,6 @@
 # Security Team
 
-The Security Team is responsible for receiving and responding to reports of security issues in KubeEdge projects.
+The Security Team is responsible for receiving and responding to reports of vulnerability in KubeEdge projects.
 
 ## Contact
 

--- a/team-security/security-groups.md
+++ b/team-security/security-groups.md
@@ -2,26 +2,28 @@
 
 ### Distributors announce
 
-File an issue [here](https://github.com/kubeedge/community/issues/new?template=distributors-application.md), filling in the criteria template to join [cncf-kubeedge-distrib-announce@lists.cncf.io](mailto:cncf-kubeedge-distrib-announce@lists.cncf.io).
-
-Announce Email:
+Email:
 
 cncf-kubeedge-distrib-announce@lists.cncf.io
 
 Maintained by [Security Team](#the-security-team).
 
-Distributors Members:
+Members:
+
+File an issue [here](https://github.com/kubeedge/community/issues/new?template=distributors-application.md), filling in the criteria template to join [cncf-kubeedge-distrib-announce@lists.cncf.io](mailto:cncf-kubeedge-distrib-announce@lists.cncf.io).
 
 - kubeedge-security@daocloud.io
 
 
 ### The Security Team
 
-Receive Vulnerability Email:
+Email:
 
 cncf-kubeedge-security@lists.cncf.io
 
 Members:
+
+Members are responsible for receiving and handling vulnerabilities. The appointment or replacement of members is recommended by existing members or the TSC, and is approved by a TSC vote finally.
 
 - [wangzefeng@huawei.com](mailto:wangzefeng@huawei.com)
 - [xufei40@huawei.com](mailto:xufei40@huawei.com)

--- a/team-security/security-groups.md
+++ b/team-security/security-groups.md
@@ -1,32 +1,25 @@
 ## KubeEdge security mailing lists
 
-File an issue [here](https://github.com/kubeedge/community/issues/new?template=distributors-application.md), filling in the criteria template to join [cncf-kubeedge-distrib-announce@lists.cncf.io](mailto:cncf-kubeedge-distrib-announce@lists.cncf.io).
-
 ### Distributors announce
 
-Email:
+File an issue [here](https://github.com/kubeedge/community/issues/new?template=distributors-application.md), filling in the criteria template to join [cncf-kubeedge-distrib-announce@lists.cncf.io](mailto:cncf-kubeedge-distrib-announce@lists.cncf.io).
+
+Announce Email:
 
 cncf-kubeedge-distrib-announce@lists.cncf.io
 
 Maintained by [Security Team](#the-security-team).
 
-Members:
+Distributors Members:
 
 - kubeedge-security@daocloud.io
 
 
 ### The Security Team
 
-Email:
+Receive Vulnerability Email:
 
 cncf-kubeedge-security@lists.cncf.io
-
-Owners:
-
-- [wangzefeng@huawei.com](mailto:wangzefeng@huawei.com)
-- [xufei40@huawei.com](mailto:xufei40@huawei.com)
-- [linguohui1@huawei.com](mailto:linguohui1@huawei.com)
-- [wei.hu@daocloud.io](mailto:wei.hu@daocloud.io)
 
 Members:
 


### PR DESCRIPTION
Some updates for team security as discussed with TSC: 
1. Merge security owners to members, and they have the same responsibilities.
2. Add description for how security member get appointed and replaced, the appointment or replacement of members is recommended by existing members or the TSC, and is approved by a TSC vote finally.