### PR TITLE
Update TSC members based on 2025 elections results

### DIFF
--- a/committee-technical-steering/README.md
+++ b/committee-technical-steering/README.md
@@ -13,7 +13,7 @@ The initial TSC members are picked by the [project maintainers](https://github.c
 | Name           | Employer     | Term End |
 |----------------|--------------|----------|
 | Benjamin Huo   | QingCloud    | 2027     |
-| Hongbing Zhang | DaoCloud     | 2027     | 
+| Hongbing Zhang | DaoCloud     | 2027     |
 | Huan Wei       | HarmonyCloud | 2026     |
 | Kevin Wang     | Huawei       | 2026     |
 | Tina Tsou      | TikTok       | 2026     |


### PR DESCRIPTION
According to the election charter: _If the number of Qualified Nominees is equal to or less than the number of TSC seats available to be elected, the Qualified Nominees shall be approved after the nomination period has closed._ 

Since the number of candidates is equal to the number of available seats, the four candidates will directly obtain TSC seats. 

From today until October 15th, we will enter the public announcement phase. If you have any objections, please feel free to raise them at any time.